### PR TITLE
switch from RestTemplate into OkHttp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation('org.modelmapper:modelmapper:2.3.6')
     implementation('org.springframework.boot:spring-boot-starter-validation')
     implementation('org.apache.commons:commons-lang3:3.10')
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.0'
     annotationProcessor('org.projectlombok:lombok')
     runtimeOnly('com.h2database:h2')
     testImplementation('org.springframework.boot:spring-boot-starter-test')

--- a/src/main/java/com/app/car/rental/backend/service/avis/AvisLocationService.java
+++ b/src/main/java/com/app/car/rental/backend/service/avis/AvisLocationService.java
@@ -2,22 +2,30 @@ package com.app.car.rental.backend.service.avis;
 
 import com.app.car.rental.backend.api.avis.model.location.AvisApiLocation;
 import com.app.car.rental.backend.api.avis.model.token.AvisApiToken;
+import com.app.car.rental.backend.web.controller.RestTemplateResponseErrorHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
+import java.util.Collections;
 import java.util.logging.Logger;
 
 @Service
 public class AvisLocationService {
     public static final Logger LOGGER = Logger.getLogger(AvisLocationService.class.getName());
+
+    private static final String SERVER_URL = "https://stage.abgapiservices.com/cars/locations/v1";
 
     @Autowired
     private AvisTokenService avisTokenService;
@@ -27,38 +35,38 @@ public class AvisLocationService {
         String authorizationToken = avisApiToken.getTokenType() + " " + avisApiToken.getAccessToken();
 
         RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new RestTemplateResponseErrorHandler());
 
         HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
         headers.add("client_id", "2d8fd8f532234bd484e512d83aec3b4e");
-        //headers.add("Authorization", "Bearer 00013Q4W10DuJxMARsRt9DlG5i2U");
         headers.add("Authorization", authorizationToken);
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        //body.add("file", getTestFile());
-
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
-        String serverUrl = "https://stage.abgapiservices.com/cars/locations/v1";
+        UriComponents builder = UriComponentsBuilder
+                .fromUriString(SERVER_URL)
+//                .queryParam("keyword", location)
+                .queryParam("keyword", "warsaw")
+                .build(true);
 
-//        Map<String, String> parameters = new HashMap<>();
-//        parameters.put("lat", "42.3736861242963");
-//        parameters.put("long", "-71.029931402219");
+        ResponseEntity<AvisApiLocation> response = ResponseEntity.noContent().build();
 
-        UriComponentsBuilder builder = UriComponentsBuilder
-                .fromUriString(serverUrl)
-                .queryParam("keyword", location);
-                // Add query parameter
-                //.queryParam("lat", "42.3736861242963")
-                //.queryParam("long", "-71.029931402219");
+        try {
+            response = restTemplate.exchange(builder.toUri(), HttpMethod.GET, requestEntity, AvisApiLocation.class);
+            URI uri = builder.toUri();
+            LOGGER.info("#### url: " + uri);
+//            AvisApiLocation avisApiLocation = restTemplate.postForObject(uri, requestEntity, AvisApiLocation.class);
+            LOGGER.info("#### responseBody: " + response.getBody());
+//            LOGGER.info("#### avisApiLocation: " + avisApiLocation);
+        } catch (RestClientException e) {
+            LOGGER.info("#### exception message: " + e.getMessage());
+            LOGGER.info("#### response body: " + response);
+            e.printStackTrace();
+        }
 
-        //String response = restTemplate.getForObject(builder.toUriString(), String.class);
-        //ResponseEntity<String> response = restTemplate.exchange(builder.toUriString(), HttpMethod.GET, requestEntity, String.class);
-        ResponseEntity<AvisApiLocation> response = restTemplate.exchange(builder.toUriString(), HttpMethod.GET, requestEntity, AvisApiLocation.class);
-        //ResponseEntity<String> response = restTemplate.getForEntity(serverUrl, String.class, parameters);
-        //String responseBody = response.getBody();
-        LOGGER.info("#### responseBody: " + response.getBody());
-        LOGGER.info("#### locations: " + response.getBody().getLocations());
         return response.getBody();
-
     }
 }

--- a/src/main/java/com/app/car/rental/backend/service/avis/AvisReservationOkHttpService.java
+++ b/src/main/java/com/app/car/rental/backend/service/avis/AvisReservationOkHttpService.java
@@ -1,0 +1,78 @@
+package com.app.car.rental.backend.service.avis;
+
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.AvisApiReservationPostRequest;
+import com.app.car.rental.backend.api.avis.model.reservation.post.response.AvisApiReservationPostResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.Call;
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+@Service
+public class AvisReservationOkHttpService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AvisReservationOkHttpService.class);
+
+    private static final String SERVER_URL = "https://stage.abgapiservices.com/cars/reservation/v1";
+
+    private final AvisTokenService avisTokenService;
+
+    public AvisReservationOkHttpService(AvisTokenService avisTokenService) {
+        this.avisTokenService = avisTokenService;
+    }
+
+    public AvisApiReservationPostResponse reservations(AvisApiReservationPostRequest avisApiReservation) throws IOException {
+        LOGGER.info("reservations({})", avisApiReservation);
+
+        String authorizationToken = avisTokenService.authorizationToken();
+
+        OkHttpClient client = new OkHttpClient();
+
+        HashMap<String, String> headersMap = new HashMap<>();
+        headersMap.put("client_id", "2d8fd8f532234bd484e512d83aec3b4e");
+        headersMap.put("Authorization", authorizationToken);
+        headersMap.put("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+
+        Headers headers = Headers.of(headersMap);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestBodyString = objectMapper.writeValueAsString(avisApiReservation);
+        RequestBody requestBody = RequestBody.create(okhttp3.MediaType.parse("application/json; charset=utf-8"), requestBodyString);
+
+        Request request = new Request.Builder()
+                .url(SERVER_URL)
+                .headers(headers)
+                .post(requestBody)
+                .build();
+
+        Call call = client.newCall(request);
+        Response response = call.execute();
+
+        int responseStatus = response.code();
+        ResponseBody responseBody = response.body();
+
+        String responseBodyString = responseBody.string();
+        if (HttpStatus.OK.value() == responseStatus
+                || HttpStatus.CREATED.value() == responseStatus) {
+            AvisApiReservationPostResponse avisApiReservationPostResponse =
+                    objectMapper.readValue(responseBodyString, AvisApiReservationPostResponse.class);
+            LOGGER.info("avisApiReservationPostResponse: " + avisApiReservationPostResponse);
+        } else {
+            // FIXME: parse JSON with errors...
+        }
+
+        LOGGER.info("#### response body: {}", responseBodyString);
+
+        return null;
+    }
+}

--- a/src/main/java/com/app/car/rental/backend/service/avis/AvisReservationService.java
+++ b/src/main/java/com/app/car/rental/backend/service/avis/AvisReservationService.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.logging.Logger;
@@ -29,6 +30,8 @@ public class AvisReservationService {
         String authorizationToken = avisApiToken.getTokenType() + " " + avisApiToken.getAccessToken();
 
         RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new DefaultResponseErrorHandler());
+
         ObjectMapper objectMapper = new ObjectMapper();
         String bodyString = objectMapper.writeValueAsString(avisApiReservation);
 

--- a/src/main/java/com/app/car/rental/backend/service/avis/AvisTokenService.java
+++ b/src/main/java/com/app/car/rental/backend/service/avis/AvisTokenService.java
@@ -17,6 +17,14 @@ import java.util.logging.Logger;
 public class AvisTokenService {
     public static final Logger LOGGER = Logger.getLogger(AvisTokenService.class.getName());
 
+    public String authorizationToken() {
+        LOGGER.info("authorizationToken()");
+        AvisApiToken avisApiToken = token();
+        String authorizationToken = avisApiToken.getTokenType() + " " + avisApiToken.getAccessToken();
+        LOGGER.info("authorizationToken() = " + authorizationToken);
+        return authorizationToken;
+    }
+
     public AvisApiToken token(){
         RestTemplate restTemplate = new RestTemplate();
 

--- a/src/main/java/com/app/car/rental/backend/web/controller/RestTemplateResponseErrorHandler.java
+++ b/src/main/java/com/app/car/rental/backend/web/controller/RestTemplateResponseErrorHandler.java
@@ -1,10 +1,12 @@
 package com.app.car.rental.backend.web.controller;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResponseErrorHandler;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.logging.Logger;
 
 @Component
@@ -24,6 +26,11 @@ public class RestTemplateResponseErrorHandler implements ResponseErrorHandler {
     public void handleError(ClientHttpResponse response) throws IOException {
         LOGGER.info("wyloguj response" + response.getBody());
         LOGGER.info("wyloguj response" + response.getClass());
+    }
 
+    @Override
+    public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
+        LOGGER.info("wyloguj response" + response.getBody());
+        LOGGER.info("wyloguj response" + response.getClass());
     }
 }

--- a/src/test/java/com/app/car/rental/backend/service/AvisLocationServiceTest.java
+++ b/src/test/java/com/app/car/rental/backend/service/AvisLocationServiceTest.java
@@ -17,4 +17,9 @@ public class AvisLocationServiceTest {
     public void locations() {
         avisLocationService.locations("warszawa");
     }
+
+    @Test
+    public void givenLocationNull_whenServiceLocations_thenStatusError() {
+        avisLocationService.locations(null);
+    }
 }

--- a/src/test/java/com/app/car/rental/backend/service/AvisReservationRequestServiceTest.java
+++ b/src/test/java/com/app/car/rental/backend/service/AvisReservationRequestServiceTest.java
@@ -1,21 +1,35 @@
 package com.app.car.rental.backend.service;
 
-import com.app.car.rental.backend.api.avis.model.reservation.post.request.*;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Address;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.ArrivalFlight;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.AvisApiReservationPostRequest;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Contact;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Discount;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Driver;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Extra;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Insurance;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Loyalty;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Membership;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Passenger;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Product;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Rate;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.RateTotals;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Reservation;
+import com.app.car.rental.backend.api.avis.model.reservation.post.request.Transaction;
 import com.app.car.rental.backend.api.avis.model.reservation.post.response.AvisApiReservationPostResponse;
-import com.app.car.rental.backend.service.avis.AvisReservationService;
+import com.app.car.rental.backend.service.avis.AvisReservationOkHttpService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Arrays;
-
 @SpringBootTest
 @RunWith(SpringRunner.class)
 public class AvisReservationRequestServiceTest {
     @Autowired
-    private AvisReservationService avisReservationService;
+    private AvisReservationOkHttpService avisReservationOkHttpService;
+//    private AvisReservationService avisReservationService;
 
     @Test
     public void reservations() throws Exception{
@@ -32,8 +46,8 @@ public class AvisReservationRequestServiceTest {
 
         Reservation reservation = new Reservation();
         reservation.setEmailNotification(true);
-        reservation.setDropoffDate("2020-08-20T12:00:00");
-        reservation.setPickupDate("2020-08-15T12:00:00");
+        reservation.setDropoffDate("2020-12-20T12:00:00");
+        reservation.setPickupDate("2020-12-15T12:00:00");
         reservation.setPickupLocation("EWR");
         reservation.setDropoffLocation("EWR");
         reservation.setVehicleClassCode("A");
@@ -107,7 +121,7 @@ public class AvisReservationRequestServiceTest {
         //apiReservation.set
 
         //When
-        AvisApiReservationPostResponse reservations = avisReservationService.reservations(apiReservation);
+        AvisApiReservationPostResponse reservations = avisReservationOkHttpService.reservations(apiReservation);
         System.out.println(reservations);
 
         //Then


### PR DESCRIPTION
Move from Spring RestTemplate into OkHttp because of Spring throws Exception for 400 Bad Request and OkHttp doesn't, and we can handle Error Responses.